### PR TITLE
Fix forester filetype detection

### DIFF
--- a/lua/forester.lua
+++ b/lua/forester.lua
@@ -21,14 +21,7 @@ local function add_treesitter_config()
 end
 
 local function setup()
-  vim.filetype.add({ extension = { tree = "forester" }, pattern = { ["*.tree"] = "forester" } }) -- FIXME: This doesn't work?
-
-  vim.api.nvim_create_autocmd({ "BufNew", "BufEnter" }, {
-    pattern = { "*.tree" },
-    callback = function(args)
-      vim.treesitter.start(args.buf, "forester")
-    end,
-  })
+  vim.filetype.add({ extension = { tree = "forester" } })
 
   local config = Config.find_default_config()
   if config ~= "" then


### PR DESCRIPTION
The filetype detection isn't working because of this. There is no reason to start treesitter manually in this autocmd, as it is registered here:
https://github.com/kentookura/forester.nvim/blob/8cbfd5823d110be50ed0f813fe371369dbf67e9b/lua/forester.lua#L20