### PR TITLE
Fix `cmp` completion source

### DIFF
--- a/lua/forester/completion.lua
+++ b/lua/forester/completion.lua
@@ -62,7 +62,7 @@ function source:complete(params, callback)
         label = title .. " (" .. addr .. ")",
         -- label = " (" .. addr .. ")",
         insertText = addr,
-        documentation = "hello",
+        documentation = nil,
         detail = addr,
       })
     end

--- a/lua/forester/completion.lua
+++ b/lua/forester/completion.lua
@@ -46,7 +46,7 @@ function source:complete(params, callback)
   local input = string.sub(params.context.cursor_before_line, params.offset - 1)
   if vim.startswith(input, "(") then
     local items = {}
-    local trees = forester.query_all("trees")
+    local trees = forester.query_all(vim.g.forester_current_config)
     -- vim.print(vim.inspect(trees))
     for addr, data in pairs(trees) do
       -- vim.notify(vim.inspect(data.title))


### PR DESCRIPTION
Hey, thanks for your work on this plugin. I tried using the `cmp` completion source, but it would fail with the following error:

```log
Error detected while processing TextChangedI Autocommands for "*":
Error executing lua callback: ...k/packer/start/forester.nvim/lua/forester/completion.lua:49: bad argument #1 to 'query_all' (string expected, got nil)
stack traceback:
	[C]: in function 'query_all'
	...k/packer/start/forester.nvim/lua/forester/completion.lua:49: in function 'complete'
	.../nvim/site/pack/packer/start/nvim-cmp/lua/cmp/source.lua:326: in function 'complete'
	...ta/nvim/site/pack/packer/start/nvim-cmp/lua/cmp/core.lua:299: in function 'complete'
	...ta/nvim/site/pack/packer/start/nvim-cmp/lua/cmp/core.lua:169: in function 'callback'
	...ta/nvim/site/pack/packer/start/nvim-cmp/lua/cmp/core.lua:229: in function 'autoindent'
	...ta/nvim/site/pack/packer/start/nvim-cmp/lua/cmp/core.lua:161: in function 'on_change'
	...ta/nvim/site/pack/packer/start/nvim-cmp/lua/cmp/init.lua:340: in function 'callback'
	...ite/pack/packer/start/nvim-cmp/lua/cmp/utils/autocmd.lua:49: in function 'emit'
	...ite/pack/packer/start/nvim-cmp/lua/cmp/utils/autocmd.lua:23: in function <...ite/pack/packer/start/nvim-cmp/lua/cmp/utils/autocmd.lua:22>
```

I believe this is caused by not passing the correct configuration to `query_all` (6b3ff9e5be2fa622f8041826b583a191dfe0e445). There's also a random `"hello"` in the documentation view of a completion item. I believe that shouldn't be there (665346ea023796d1d6332e352d5c73570b66fd35)? I appreciate the plugin greeting me though.