### PR TITLE
Refactors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ test: deps/mini.nvim
 test_file: deps/mini.nvim
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua -c "lua MiniTest.run_file('$(FILE)')"
 
-# Download 'mini.nvim' to use its 'mini.test' testing module
+# Download dependencies:
+# TODO: remove as much as possible
 deps:
 	@mkdir -p deps
 	git clone --filter=blob:none https://github.com/echasnovski/mini.nvim $@/mini.nvim

--- a/README.md
+++ b/README.md
@@ -34,13 +34,20 @@ With lazy:
 ```lua
   {
     "kentookura/forester.nvim",
+    event = "VeryLazy",
     dependencies = {
       { "nvim-telescope/telescope.nvim" },
       { "nvim-treesitter/nvim-treesitter" },
       { "nvim-lua/plenary.nvim" },
-      { "hrsh7th/nvim-cmp" },
     },
   },
+
+  -- optionally, configure the cmp source:
+  local foresterCompletionSource = require("forester.completion")
+
+  require("cmp").register_source("forester", foresterCompletionSource)
+  require("cmp").setup.filetype("forester", { sources = { { name = "forester", dup = 0 } } })
+
 ```
 
 You might need to run `:TSInstall toml` and `:TSInstall forester`.

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             act
+            watchexec
             teseq
             forester.packages.${system}.default
             tree-sitter

--- a/lua/forester.lua
+++ b/lua/forester.lua
@@ -27,7 +27,7 @@ local config = require("forester.config")
 
 local M = {}
 
-local function add_treesitter_config()
+local function register_treesitter_parser()
   local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
   parser_config.forester = {
     install_info = {
@@ -91,7 +91,7 @@ local function setup()
   cmp.register_source("forester", completionSource)
   cmp.setup.filetype("forester", { sources = { { name = "forester", dup = 0 } } })
 
-  add_treesitter_config()
+  register_treesitter_parser()
 
   vim.opt.suffixesadd:prepend(".tree")
 

--- a/lua/forester.lua
+++ b/lua/forester.lua
@@ -46,36 +46,34 @@ local function setup()
   vim.filetype.add({ extension = { tree = "forester" } })
   local forester_group = vim.api.nvim_create_augroup("ForesterGroup", { clear = true })
 
-  local cfg = config.find_default_config()
-  if cfg ~= "" then
-    vim.g.forester_current_config = cfg
-    vim.api.nvim_create_user_command("Forester", function(cmd)
-      local prefix, _ = commands.parse(cmd.args)
-      commands.cmd(prefix)
-    end, {
-      bar = true,
-      bang = true,
-      nargs = "?",
-      complete = function(_, line)
-        local prefix, args = commands.parse(line)
-        if #args > 0 then
-          return commands.complete(prefix, args[#args])
-        end
-        return vim.tbl_filter(function(key)
-          return key:find(prefix, 1, true) == 1
-        end, vim.tbl_keys(commands.commands))
-      end,
-    })
-  end
+  vim.api.nvim_create_user_command("Forester", function(cmd)
+    local prefix, _ = commands.parse(cmd.args)
+    commands.cmd(prefix)
+  end, {
+    bar = true,
+    bang = true,
+    nargs = "?",
+    complete = function(_, line)
+      local prefix, args = commands.parse(line)
+      if #args > 0 then
+        return commands.complete(prefix, args[#args])
+      end
+      return vim.tbl_filter(function(key)
+        return key:find(prefix, 1, true) == 1
+      end, vim.tbl_keys(commands.commands))
+    end,
+  })
 
-  -- Make links followable with `gf`
+  config.set_default_config()
+
+  --- Make links followable with `gf`
   local add_treedirs_to_path = function()
-    pcall(function()
-      local dirs = config.tree_dirs()
-      for _, v in pairs(dirs) do
+    vim.opt.suffixesadd:prepend(".tree")
+    if vim.g.forester_current_config ~= nil then
+      for _, v in pairs(vim.g.forester_current_config.trees) do
         vim.opt.path:append(v)
       end
-    end)
+    end
   end
 
   vim.api.nvim_create_autocmd("User", {
@@ -86,19 +84,13 @@ local function setup()
     end,
   })
 
-  local cmp = require("cmp")
-
-  cmp.register_source("forester", completionSource)
-  cmp.setup.filetype("forester", { sources = { { name = "forester", dup = 0 } } })
-
   register_treesitter_parser()
-
-  vim.opt.suffixesadd:prepend(".tree")
 
   add_treedirs_to_path()
   ui.setup()
 end
 
+M.register_treesitter_parser = register_treesitter_parser
 M.completionSource = completionSource
 M.commands = commands
 M.ui = ui

--- a/lua/forester/bindings.lua
+++ b/lua/forester/bindings.lua
@@ -53,12 +53,17 @@ local function titles(config)
   job:sync()
   --local result = job:result()
   local out = {}
-  local result = util.map(job:result(), function(r)
+  local result = util.filter_map(job:result(), function(r)
     local addr, title = r:match("([^,]+), ([^,]+)")
-    return { addr = addr, title = title }
+    if addr == nil or title == nil then
+      return { false }
+    else
+      return { true, { addr = addr, title = title } }
+    end
   end)
-  for k, v in pairs(result) do
-    out[k] = { addr = v.addr, title = v.title }
+  for _, v in pairs(result) do
+    out[v.addr] = v.title
+    -- { addr = v.addr, title = v.title }
   end
   return out
 end

--- a/lua/forester/commands.lua
+++ b/lua/forester/commands.lua
@@ -8,7 +8,14 @@ local M = {}
 M.commands = {
   -- Select the forester configuration file to use
   config = function()
-    config.switch()
+    local configs = config.all_configs()
+    if #configs == 0 then
+      vim.notify("No forester configs available in the current directory!", vim.log.levels.WARN)
+    else
+      pickers.pick_config(configs)
+      vim.api.nvim_exec_autocmds("User", { pattern = "SwitchedForesterConfig" })
+    end
+    -- config.switch()
   end,
 
   build = function()
@@ -32,8 +39,7 @@ M.commands = {
   end,
 
   new_random = function()
-    local prefixes = config.all_prefixes()
-    vim.ui.select(prefixes, { -- TODO: Don't select when #all_prefixes == 1
+    vim.ui.select(vim.g.forester_current_config.prefixes, { -- TODO: Don't select when #prefixes == 1
       format_item = function(item)
         return item
       end,
@@ -53,8 +59,7 @@ M.commands = {
   end,
 
   new = function()
-    local prefixes = config.all_prefixes()
-    vim.ui.select(prefixes, { -- TODO: Don't select when #all_prefixes == 1
+    vim.ui.select(vim.g.forester_current_config.prefixes, { -- TODO: Don't select when #prefixes == 1
       format_item = function(item)
         return item
       end,
@@ -74,8 +79,7 @@ M.commands = {
   end,
 
   transclude_new = function()
-    local prefixes = config.all_prefixes()
-    vim.ui.select(prefixes, { -- TODO: Don't select when #all_prefixes == 1
+    vim.ui.select(vim.g.forester_current_config.prefixes, { -- TODO: Don't select when #prefiexes == 1
       format_item = function(item)
         return item
       end,
@@ -136,8 +140,17 @@ function M.cmd(cmd)
   local command = M.commands[cmd]
   if command == nil then
     vim.print("Invalid forester command '" .. cmd .. "'")
-  else
+  elseif cmd == "config" then
     command()
+  else
+    local current_cfg = vim.g.forester_current_config
+    if current_cfg == "" or current_cfg == vim.NIL or current_cfg == nil then
+      vim.notify("No forester config file is set! Use `:Forester config` to select one", vim.log.levels.WARN)
+    elseif vim.fn.executable("forester") ~= 1 then
+      vim.notify("The `forester` command is not available!", vim.log.levels.WARN)
+    else
+      command()
+    end
   end
 end
 

--- a/lua/forester/commands.lua
+++ b/lua/forester/commands.lua
@@ -101,8 +101,7 @@ M.commands = {
   end,
 
   link_new = function()
-    local prefixes = config.all_prefixes()
-    vim.ui.select(prefixes, {
+    vim.ui.select(vim.g.forester_current_config.prefixes, {
       format_item = function(item)
         return item
       end,

--- a/lua/forester/completion.lua
+++ b/lua/forester/completion.lua
@@ -5,6 +5,7 @@ local util = require("forester.util")
 local FORESTER_BUILTINS = require("forester.consts").FORESTER_BUILTINS
 local map = util.map
 local source = {}
+local cache
 
 ---Return whether this source is available in the current context or not (optional).
 ---@return boolean
@@ -53,8 +54,6 @@ for _, v in pairs(FORESTER_BUILTINS) do
   )
 end
 
-local cache
-
 local function refresh_cache()
   local success, res = pcall(forester.query_all, vim.g.forester_current_config)
   if success then
@@ -71,6 +70,25 @@ vim.api.nvim_create_autocmd({ "BufWritePost" }, {
   end,
 })
 
+function source:closing_delim(text_before_cursor)
+  local candidate = { -1, "" }
+  for _, v in pairs(triggers_for_closing_brace) do
+    local _, e = string.find(text_before_cursor, v)
+    if e ~= nil and candidate[1] < e then
+      candidate = { e, "}" }
+    end
+  end
+  local _, e = string.find(text_before_cursor, "%]%(")
+  if e ~= nil and candidate[1] < e then
+    candidate = { e, ")" }
+  end
+  local _, e = string.find(text_before_cursor, "%[%[")
+  if e ~= nil and candidate[1] < e then
+    candidate = { e, "]]" }
+  end
+  return candidate[2]
+end
+
 function source:complete(params, callback)
   local input = string.sub(params.context.cursor_before_line, params.offset - 1)
   local text_before_cursor = params.context.cursor_before_line
@@ -78,38 +96,21 @@ function source:complete(params, callback)
     callback(default_items)
   else
     local items = {}
-    local prefix_items = map(config.all_prefixes(), function(pfx)
+    local prefix_items = map(vim.g.forester_current_config.prefixes, function(pfx)
       return {
         label = pfx,
         documentation = "create a new tree with prefix `" .. pfx .. "`",
         data = { isPrefix = true },
       }
     end)
-    local function closing_delim()
-      local candidate = { -1, "" }
-      for _, v in pairs(triggers_for_closing_brace) do
-        local _, e = string.find(text_before_cursor, v)
-        if e ~= nil and candidate[1] < e then
-          candidate = { e, "}" }
-        end
-      end
-      local _, e = string.find(text_before_cursor, "%]%(")
-      if e ~= nil and candidate[1] < e then
-        candidate = { e, ")" }
-      end
-      local _, e = string.find(text_before_cursor, "%[%[")
-      if e ~= nil and candidate[1] < e then
-        candidate = { e, "]]" }
-      end
-      return candidate[2]
-    end
-    local prefix_random_items = map(config.all_prefixes(), function(pfx)
+
+    local prefix_random_items = map(vim.g.forester_current_config.prefixes, function(pfx)
       return {
         label = pfx,
         filterText = pfx .. " " .. "random",
         documentation = "create a new tree with prefix `" .. pfx .. "` (randomized id)",
         labelDetails = { description = "random" },
-        data = { isPrefix = true, isRandom = true, closingDelim = closing_delim() },
+        data = { isPrefix = true, isRandom = true, closingDelim = source:closing_delim() },
       }
     end)
     for _, v in pairs(prefix_items) do
@@ -119,7 +120,7 @@ function source:complete(params, callback)
       table.insert(items, v)
     end
     local function insert_text(addr)
-      return addr .. closing_delim()
+      return addr .. source:closing_delim()
     end
     for addr, data in pairs(cache) do
       local title

--- a/lua/forester/completion.lua
+++ b/lua/forester/completion.lua
@@ -110,7 +110,7 @@ function source:complete(params, callback)
         filterText = pfx .. " " .. "random",
         documentation = "create a new tree with prefix `" .. pfx .. "` (randomized id)",
         labelDetails = { description = "random" },
-        data = { isPrefix = true, isRandom = true, closingDelim = source:closing_delim() },
+        data = { isPrefix = true, isRandom = true, closingDelim = source:closing_delim(text_before_cursor) },
       }
     end)
     for _, v in pairs(prefix_items) do
@@ -120,7 +120,7 @@ function source:complete(params, callback)
       table.insert(items, v)
     end
     local function insert_text(addr)
-      return addr .. source:closing_delim()
+      return addr .. source:closing_delim(text_before_cursor)
     end
     for addr, data in pairs(cache) do
       local title

--- a/lua/forester/config.lua
+++ b/lua/forester/config.lua
@@ -174,6 +174,6 @@ end
 
 M.parse = parse
 M.set_default_config = set_default_config
-M.switch = switch
+M.all_configs = all_configs
 
 return M

--- a/lua/forester/pickers.lua
+++ b/lua/forester/pickers.lua
@@ -1,3 +1,4 @@
+local config = require("forester.config")
 local strings = require("plenary.strings")
 local pickers = require("telescope.pickers")
 local finders = require("telescope.finders")
@@ -25,7 +26,7 @@ local pick_config = function(config_files, opts)
         actions.select_default:replace(function()
           actions.close(prompt_bufnr)
           local selection = action_state.get_selected_entry()
-          vim.g.forester_current_config = selection[1]
+          vim.g.forester_current_config = config.parse(selection[1])
         end)
         return true
       end,

--- a/lua/forester/ui.lua
+++ b/lua/forester/ui.lua
@@ -1,20 +1,13 @@
 -- This is code is WIP and does not get used yet.
 local api = vim.api
 local forester = require("forester.bindings")
-local filter_map = require("forester.util").filter_map
 
 local M = {}
 
 local function create_title_cache()
-  local success, trees = pcall(forester.query_all, vim.g.forester_current_config)
+  local success, trees = pcall(forester.titles, vim.g.forester_current_config)
   if success then
-    return filter_map(trees, function(tree)
-      if tree.title ~= "" then
-        return { true, tree.title }
-      else
-        return { false }
-      end
-    end)
+    return trees
   else
     return {}
   end

--- a/lua/forester/util.lua
+++ b/lua/forester/util.lua
@@ -5,14 +5,6 @@ local os_sep = path.path.sep
 
 local M = {}
 
---local addr = item:match("[^, ]*$")
---local title = item:match("[^,]+$")
-local function add_tree_dirs_to_path(dirs)
-  for _, v in pairs(dirs) do
-    vim.opt.path:append(v)
-  end
-end
-
 local function filename(url)
   return url:match("[^/]+$")
 end
@@ -223,7 +215,6 @@ M.filter = filter
 M.filter_map = filter_map
 M.fold = fold
 M.compare_addr = compare_addr
-M.add_tree_dirs_to_path = add_tree_dirs_to_path
 M.filename = filename
 M.highest_in_dir = highest_in_dir
 

--- a/tests/hooks.lua
+++ b/tests/hooks.lua
@@ -1,0 +1,38 @@
+local path = require("plenary.path")
+local config = require("forester.config")
+
+local M = {}
+
+local dirs = { "trees", "foo", "bar" }
+local cfg = path:new("forest.toml")
+local t1 = path:new("trees/foo-0001.tree")
+local t2 = path:new("trees/t2.tree")
+local t3 = path:new("trees/t3.tree")
+
+local clean_test_forest = function()
+  for _, dir in pairs(dirs) do
+    path:new(dir):rm({ recursive = true })
+  end
+  path.rm(cfg)
+end
+
+local setup_test_forest = function()
+  for _, dir in pairs(dirs) do
+    path:new(dir):mkdir()
+  end
+  cfg:write(
+    '[forest]\
+trees = ["trees", "foo", "bar"]\
+prefixes = ["test", "pfx"]',
+    "w",
+    438
+  )
+  t1:write("\\transclude{t2}", "w")
+  t2:write("[asdf](t3)", "w", 438)
+  t3:write("\\title{asdf}", "w", 438)
+  -- vim.g.forester_current_config = config.parse("forest.toml")
+end
+
+M.clean_test_forest = clean_test_forest
+M.setup_test_forest = setup_test_forest
+return M

--- a/tests/test_bindings.lua
+++ b/tests/test_bindings.lua
@@ -5,8 +5,12 @@ local expect, eq = MiniTest.expect, MiniTest.expect.equality
 local T = MiniTest.new_set()
 local hooks = require("tests.hooks")
 
-T["bindings"] =
-  MiniTest.new_set({ hooks = { pre_once = hooks.setup_test_forest, post_once = hooks.clean_test_forest } })
+T["bindings"] = MiniTest.new_set({
+  hooks = {
+    pre_once = hooks.setup_test_forest,
+    post_once = hooks.clean_test_forest,
+  },
+})
 
 T["bindings"]["build"] = function()
   local res = forester.build("forest.toml", { no_assets = true, no_theme = true })

--- a/tests/test_bindings.lua
+++ b/tests/test_bindings.lua
@@ -1,45 +1,26 @@
+package.path = package.path .. ";./?.lua"
+
 local forester = require("forester.bindings")
-local config = require("forester.config")
-local path = require("plenary.path")
-local map = require("forester.util").map
 local expect, eq = MiniTest.expect, MiniTest.expect.equality
 local T = MiniTest.new_set()
+local hooks = require("tests.hooks")
 
-local test_forest = path:new("test_forest")
-local cfg = path:new("forest.toml")
-
-local clean_test_forest = function()
-  path.rmdir(test_forest)
-  path.rm(cfg)
-end
-
-local setup_test_forest = function()
-  local p = path:new("trees")
-  p:mkdir()
-  cfg:write(
-    '[forest]\
-trees = ["trees", "foo", "bar"]\
-prefixes = ["test", "pfx"]',
-    "w",
-    438
-  )
-  vim.g.forester_current_config = "forest.toml"
-end
-
-T["bindings"] = MiniTest.new_set({ hooks = { pre_once = setup_test_forest, post_once = clean_test_forest } })
-
-T["bindings"]["config"] = function()
-  local expected_tree_dirs = { "trees", "foo", "bar" }
-  local cwd = map(expected_tree_dirs, function(p)
-    return path:new(p):absolute()
-  end)
-  eq(config.all_prefixes(), { "test", "pfx" })
-  eq(config.tree_dirs(), cwd)
-end
+T["bindings"] =
+  MiniTest.new_set({ hooks = { pre_once = hooks.setup_test_forest, post_once = hooks.clean_test_forest } })
 
 T["bindings"]["build"] = function()
   local res = forester.build("forest.toml", { no_assets = true, no_theme = true })
   eq(res, {})
+end
+
+T["bindings"]["titles"] = function()
+  local res = forester.titles(vim.g.forester_current_config)
+  eq(res, { t3 = "asdf" })
+end
+
+T["bindings"]["new"] = function()
+  local res = forester.new("foo", "trees", vim.g.forester_current_config)
+  eq(res, { "trees/foo-0002.tree" })
 end
 
 T["bindings"]["new_tree"] = function() end

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -1,0 +1,70 @@
+local forester = require("forester")
+local commands = require("forester.commands").commands
+local expect, eq = MiniTest.expect, MiniTest.expect.equality
+local child = MiniTest.new_child_neovim()
+local hooks = require("tests.hooks")
+
+local T = MiniTest.new_set({
+  hooks = {
+    pre_once = function()
+      hooks.setup_test_forest()
+    end,
+    pre_case = function()
+      child.restart({ "-u", "scripts/minimal_init.lua" })
+      child.bo.readonly = false
+      child.lua([[
+        require('forester').setup()
+        commands = require('forester.commands').commands
+      ]])
+    end,
+    post_once = function()
+      child.stop()
+      -- hooks.clean_test_forest()
+    end,
+  },
+})
+
+T["browse"] = function()
+  expect.no_error(function()
+    child.lua([[commands.browse()]])
+  end)
+end
+
+T["build"] = function()
+  expect.no_error(function()
+    child.lua([[commands.build()]])
+  end)
+end
+
+T["config"] = function()
+  expect.no_error(function()
+    child.lua([[commands.config()]])
+  end)
+end
+
+-- TODO: figure out how to test commands that modify the buffer
+T["link_new"] = function()
+  expect.no_error(function()
+    -- child.lua([[commands.link_new()]])
+  end)
+end
+
+T["new"] = function()
+  expect.no_error(function()
+    -- child.lua([[commands.new()]])
+  end)
+end
+
+T["new_random"] = function()
+  expect.no_error(function()
+    -- child.lua([[commands.new_random()]])
+  end)
+end
+
+T["transclude_new"] = function()
+  expect.no_error(function()
+    -- child.lua([[commands.transclude_new()]])
+  end)
+end
+
+return T

--- a/tests/test_completion.lua
+++ b/tests/test_completion.lua
@@ -1,0 +1,17 @@
+local new_set = MiniTest.new_set
+local expect, eq = MiniTest.expect, MiniTest.expect.equality
+local completion = require("forester.completion")
+
+local T = new_set()
+
+-- Actual tests definitions will go here
+
+T["closing delimiters"] = function()
+  eq(completion:closing_delim("\\transclude{foo"), "}")
+  eq(completion:closing_delim("abcdefg \\import{123-"), "}")
+  eq(completion:closing_delim("safd \\author{"), "}")
+  eq(completion:closing_delim("[testing it](foo-00"), ")")
+  eq(completion:closing_delim("dfsfdadf[[wikilinks"), "]]")
+end
+
+return T

--- a/tests/test_config.lua
+++ b/tests/test_config.lua
@@ -1,0 +1,19 @@
+package.path = package.path .. ";./?.lua"
+
+local path = require("plenary.path")
+local map = require("forester.util").map
+local config = require("forester.config")
+local expect, eq = MiniTest.expect, MiniTest.expect.equality
+local hooks = require("tests.hooks")
+
+local T = MiniTest.new_set({ hooks = { pre_once = hooks.setup_test_forest, post_once = hooks.clean_test_forest } })
+
+-- local config_path = path:new("forest.toml")
+
+T["config"] = function()
+  local parsed = config.parse("forest.toml")
+
+  eq(parsed, { trees = { "trees", "foo", "bar" }, prefixes = { "test", "pfx" } })
+end
+
+return T

--- a/tests/test_forester.lua
+++ b/tests/test_forester.lua
@@ -1,15 +1,23 @@
+package.path = package.path .. ";./?.lua"
+
+local hooks = require("tests.hooks")
 local new_set = MiniTest.new_set
 local expect, eq = MiniTest.expect, MiniTest.expect.equality
 
-local T = new_set()
+local forester = require("forester")
 
--- Actual tests definitions will go here
+local T = MiniTest.new_set({ hooks = { pre_once = hooks.setup_test_forest, post_once = hooks.clean_test_forest } })
 
-T["works"] = function()
-  local x = 1 + 1
-  if x ~= 2 then
-    error("`x` is not equal to 2")
-  end
+T["setup"] = function()
+  expect.no_error(function()
+    forester.setup()
+  end)
+end
+
+T["treesitter"] = function()
+  expect.no_error(function()
+    forester.register_treesitter_parser()
+  end)
 end
 
 return T


### PR DESCRIPTION
- g:forester_current_config is now a struct with the same fields as the toml file
- more tests

Breaking changes:

- [nvim-cmp](https://github.com/hrsh7th/nvim-cmp/) completion source must now be set up manually. This used to be done in forester.setup(), but I want to minimize the set of mandatory dependencies:

```lua
local foresterCompletionSource = require("forester.completion")

require("cmp").register_source("forester", foresterCompletionSource)
require("cmp").setup.filetype("forester", { sources = { { name = "forester", dup = 0 } } })
```